### PR TITLE
Support more conventional extension mapping styles.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     description='A teeny Python library for creating Python dicts from '
         'protocol buffers and the reverse. Useful as an intermediate step before '
         'serialisation (e.g. to JSON).',
-    version='0.0.8',
+    version='0.2.0',
     author='Ben Hodgson',
     author_email='ben@benhodgson.com',
     url='https://github.com/benhodgson/protobuf-to-dict',

--- a/src/tests/test_proto_to_dict.py
+++ b/src/tests/test_proto_to_dict.py
@@ -1,12 +1,13 @@
 import unittest
 from tests.sample_pb2 import MessageOfTypes, extDouble, extString, NestedExtension
-from protobuf_to_dict import protobuf_to_dict, dict_to_protobuf
+from protobuf_to_dict import *
 import base64
 import nose.tools
 import json
 
 
 class Test(unittest.TestCase):
+
     def test_basics(self):
         m = self.populate_MessageOfTypes()
         d = protobuf_to_dict(m)
@@ -97,8 +98,8 @@ class Test(unittest.TestCase):
         m = MessageOfTypes()
         m.dubl = 1.7e+308
         m.flot = 3.4e+038
-        m.i32 = 2 ** 31 - 1 # 2147483647 #
-        m.i64 = 2 ** 63 - 1 #0x7FFFFFFFFFFFFFFF
+        m.i32 = 2 ** 31 - 1  # 2147483647 #
+        m.i64 = 2 ** 63 - 1  # 0x7FFFFFFFFFFFFFFF
         m.ui32 = 2 ** 32 - 1
         m.ui64 = 2 ** 64 - 1
         m.si32 = -1 * m.i32
@@ -112,7 +113,7 @@ class Test(unittest.TestCase):
         m.byts = b'\n\x14\x1e'
         assert len(m.byts) == 3, len(m.byts)
         m.nested.req = "req"
-        m.enm = MessageOfTypes.C #@UndefinedVariable
+        m.enm = MessageOfTypes.C  # @UndefinedVariable
         m.enmRepeated.extend([MessageOfTypes.A, MessageOfTypes.C])
         m.range.extend(range(10))
         return m
@@ -120,7 +121,7 @@ class Test(unittest.TestCase):
     def compare(self, m, d, exclude=None):
         i = 0
         exclude = ['byts', 'nested'] + (exclude or [])
-        for i, field in enumerate(MessageOfTypes.DESCRIPTOR.fields): #@UndefinedVariable
+        for i, field in enumerate(MessageOfTypes.DESCRIPTOR.fields):  # @UndefinedVariable
             if field.name not in exclude:
                 assert field.name in d, field.name
                 assert d[field.name] == getattr(m, field.name), (field.name, d[field.name])
@@ -139,12 +140,70 @@ class Test(unittest.TestCase):
 
         # Confirm compatibility with JSON serialization
         res = json.loads(json.dumps(protobuf_to_dict(m)))
-        assert '___X' in res
+        expected = {u'___X': {u'100': 123.4,
+                              u'101': u'string',
+                              u'102': 4,
+                              u'103': {u'req': u'nested'}}}
+        self.assertEqual(expected, res)
         exts = res['___X']
         assert set(exts.keys()) == set([str(f.number) for f, _ in m.ListFields() if f.is_extension])
         for key, value in primitives.items():
             assert exts[str(key.number)] == value
         assert exts[str(NestedExtension.extNested.number)]['req'] == 'nested'
+
+        deser = dict_to_protobuf(MessageOfTypes, res)
+        assert deser
+        for key, value in primitives.items():
+            assert deser.Extensions[key] == m.Extensions[key]
+        assert deser.Extensions[NestedExtension.extNested].req == m.Extensions[NestedExtension.extNested].req
+
+    def test_short_extensions(self):
+        m = MessageOfTypes()
+
+        primitives = {extDouble: 123.4, extString: "string", NestedExtension.extInt: 4}
+
+        for key, value in primitives.items():
+            m.Extensions[key] = value
+        m.Extensions[NestedExtension.extNested].req = "nested"
+
+        # Confirm compatibility with JSON serialization
+        res = json.loads(json.dumps(protobuf_to_dict(m, extensions=SHORT_EXTENSIONS)))
+        expected = {u'extDouble': 123.4,
+                    u'extInt': 4,
+                    u'extNested': {u'req': u'nested'},
+                    u'extString': u'string'}
+        self.assertEqual(expected, res)
+        self.assertEqual(set(res.keys()), set([str(f.name) for f, _ in m.ListFields() if f.is_extension]))
+        for key, value in primitives.items():
+            assert res[key.name] == value
+        assert res[str(NestedExtension.extNested.name)]['req'] == 'nested'
+
+        deser = dict_to_protobuf(MessageOfTypes, res)
+        assert deser
+        for key, value in primitives.items():
+            assert deser.Extensions[key] == m.Extensions[key]
+        assert deser.Extensions[NestedExtension.extNested].req == m.Extensions[NestedExtension.extNested].req
+
+    def test_full_extensions(self):
+        m = MessageOfTypes()
+
+        primitives = {extDouble: 123.4, extString: "string", NestedExtension.extInt: 4}
+
+        for key, value in primitives.items():
+            m.Extensions[key] = value
+        m.Extensions[NestedExtension.extNested].req = "nested"
+
+        # Confirm compatibility with JSON serialization
+        res = json.loads(json.dumps(protobuf_to_dict(m, extensions=FULL_EXTENSIONS)))
+        expected = {u'tests.extDouble': 123.4,
+                    u'tests.NestedExtension.extInt': 4,
+                    u'tests.NestedExtension.extNested': {u'req': u'nested'},
+                    u'tests.extString': u'string'}
+        self.assertEqual(expected, res)
+        self.assertEqual(set(res.keys()), set([str(f.full_name) for f, _ in m.ListFields() if f.is_extension]))
+        for key, value in primitives.items():
+            assert res[key.full_name] == value
+        assert res[str(NestedExtension.extNested.full_name)]['req'] == 'nested'
 
         deser = dict_to_protobuf(MessageOfTypes, res)
         assert deser


### PR DESCRIPTION
Support two new styles bidirectionally, in addition to the original terse default:

Terse (old style, still default)
```
>>> protobuf_to_dict.protobuf_to_dict(a)
{'___X': {'100': {'id': u'...'}}}
```

Short (nice for display, but does not resolve conflicts)
```
>>> protobuf_to_dict.protobuf_to_dict(a, extensions=1)
{'person': {'id': u'...'}
...
```

Full
```
>>> protobuf_to_dict.protobuf_to_dict(a, extensions=2)
{'activitystrea.ms.v2_0.objects.Person.person': {'id': '...'},
...
```